### PR TITLE
Missing entities from spec file cause needless exceptions.

### DIFF
--- a/tntfuzzer/httpoperation.py
+++ b/tntfuzzer/httpoperation.py
@@ -30,20 +30,22 @@ class HttpOperation:
         url = self.url
         form_data = dict()
 
-        for parameter in self.op_infos['parameters']:
-            # catch path parameters and replace them in url
-            if 'path' == parameter['in']:
-                url = self.replace_url_parameter(type_definitions, url, parameter['name'], parameter['type'])
+        # I know this isn't much of a fuzz.. but some paths in specs have no parameters
+        if 'parameters' in self.op_infos:
+            for parameter in self.op_infos['parameters']:
+                # catch path parameters and replace them in url
+                if 'path' == parameter['in']:
+                    url = self.replace_url_parameter(type_definitions, url, parameter['name'], parameter['type'])
 
-            if 'body' == parameter['in']:
-                self.request_body = self.create_body(type_definitions, parameter)
-                self.request_body = self.fuzz(self.request_body)
+                if 'body' == parameter['in']:
+                    self.request_body = self.create_body(type_definitions, parameter)
+                    self.request_body = self.fuzz(self.request_body)
 
-            if 'formData' == parameter['in'] or 'query' == parameter['in']:
-                type_cls = parameter['type']
-                if 'array' == type_cls:
-                    type_cls = parameter['items']['type']
-                form_data[parameter['name']] = self.create_form_parameter(type_definitions, type_cls)
+                if 'formData' == parameter['in'] or 'query' == parameter['in']:
+                    type_cls = parameter['type']
+                    if 'array' == type_cls:
+                        type_cls = parameter['items']['type']
+                    form_data[parameter['name']] = self.create_form_parameter(type_definitions, type_cls)
 
         if self.op_code == 'post':
             if bool(form_data):

--- a/tntfuzzer/tntfuzzer.py
+++ b/tntfuzzer/tntfuzzer.py
@@ -2,6 +2,10 @@ import argparse
 
 import termcolor
 from bravado.client import SwaggerClient
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 from __init__ import __version__
 from curlcommand import CurlCommand
@@ -20,34 +24,54 @@ class TntFuzzer:
     def start(self):
         print('Fetching open API from: ' + self.url)
 
-        protocol = None
-
-        if "https:" in self.url:
-            protocol = 'https://'
-        else:
-            protocol = 'http://'
+        # Try to find the protocol, host and basePath from the Swagger spec.
+        # host and schemes can be omitted, and the "standard" says you should use the spec's URL to derive them.
+        # https://swagger.io/docs/specification/2-0/api-host-and-base-path/
+        schemes = []
+        host = None
+        basePath = None
 
         client = SwaggerClient.from_url(self.url)
         spec = client.swagger_spec.spec_dict
+        specURL = urlparse(self.url)
 
-        host_basepath = spec['host'] + spec['basePath']
+        if 'schemes' in spec:
+            schemes = spec['schemes']
+        else:
+            # fake the array we'd find in the spec
+            schemes.append(specURL.scheme)
+            self.log_operation(None, self.url, {"status_code": "000", "documented_reason": "Specification: no schemes entry, fallback to spec URL scheme", "body": "Specification: host entry not present in Swagger spec"}, '')
+
+        if 'host' in spec:
+            host = spec['host']
+        else:
+            host = specURL.netloc
+            self.log_operation(None, self.url, {"status_code": "000", "documented_reason": "Specification: no host entry, fallback to spec URL host", "body":  "Specification: schemes entry not present in Swagger spec"}, '')
+
+        # There is no nice way to derive the basePath from the spec's URL. They *have* to include it
+        if 'basePath' not in spec:
+            self.log_operation(None, self.url, {"status_code": "000", "body": "Specification Error: basePath entry missing from Swagger spec"}, '')
+        host_basepath = host + spec['basePath']
         paths = spec['paths']
         type_definitions = spec['definitions']
-        for path_key in paths.keys():
-            path = paths[path_key]
+        # the specifcation can list multiple schemes (http, https, ws, wss) - all should be tested.
+        # Each scheme is a potentially different end point
+        for protocol in schemes:
+            for path_key in paths.keys():
+                path = paths[path_key]
 
-            for op_code in path.keys():
-                operation = HttpOperation(op_code, protocol + host_basepath, path_key,
-                                          op_infos=path[op_code], use_fuzzing=True)
+                for op_code in path.keys():
+                    operation = HttpOperation(op_code, protocol + '://' + host_basepath, path_key,
+                                              op_infos=path[op_code], use_fuzzing=True)
 
-                for x in range(self.iterations):
-                    response = operation.execute(type_definitions)
-                    validator = ResultValidator()
-                    log = validator.evaluate(response, path[op_code]['responses'], self.log_unexpected_errors_only)
-                    curlcommand = CurlCommand(response.url, operation.op_code, operation.request_body)
+                    for x in range(self.iterations):
+                        response = operation.execute(type_definitions)
+                        validator = ResultValidator()
+                        log = validator.evaluate(response, path[op_code]['responses'], self.log_unexpected_errors_only)
+                        curlcommand = CurlCommand(response.url, operation.op_code, operation.request_body)
 
-                    # log to screen for now
-                    self.log_operation(operation.op_code, response.url, log, curlcommand)
+                        # log to screen for now
+                        self.log_operation(operation.op_code, response.url, log, curlcommand)
 
     def log_operation(self, op_code, url, log, curlcommand):
         status_code = str(log['status_code'])


### PR DESCRIPTION
Add: Schemes should be used from the spec, and if missing should be
derived from spec URL
Bugfix: "parameters" can be missing from a path's http method. In this
case we skip over the parameter part (poor fuzz - but let's code run)
Bugfix: Host should be used from the spec file, and if missing should be derived from the spec URL