### PR TITLE
[WIP] Add the possibility to send api keys

### DIFF
--- a/tests/curlcommandtest.py
+++ b/tests/curlcommandtest.py
@@ -12,7 +12,7 @@ class CurlCommandTest(TestCase):
         headers = u'{}'
         curlcommand = CurlCommand(url, method, data, headers)
 
-        self.assertEquals(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" -d " 
+        self.assertEquals(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" -d "
                                              "'{\"id\": 1, \"name\": \"Foo\"}' http://example.com/api/v2/test")
 
     def test_post_method(self):

--- a/tests/curlcommandtest.py
+++ b/tests/curlcommandtest.py
@@ -32,3 +32,13 @@ class CurlCommandTest(TestCase):
         curlcommand = CurlCommand(url, method, data)
         self.assertEquals(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" "
                                              "http://example.com/api/v2/list")
+
+    def test_generate_headers(self):
+        method = "get"
+        url = "http://example.com/api/v2/list"
+        data = ""
+        headers = '{ \"X-API-Key\": \"abcdef12345\", \"user-agent\": \"tntfuzzer\" }'
+        expected_result = u'-H \"Content-type: application/json\" -H \"X-API-Key\": \"abcdef12345\" ' \
+                          u'-H \"user-agent\": \"tntfuzzer\"'
+        curlcommand = CurlCommand(url, method, data, headers)
+        self.assertEquals(curlcommand.generate_headers(), expected_result)

--- a/tests/curlcommandtest.py
+++ b/tests/curlcommandtest.py
@@ -12,7 +12,7 @@ class CurlCommandTest(TestCase):
         headers = u'{}'
         curlcommand = CurlCommand(url, method, data, headers)
 
-        self.assertEquals(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" -d "
+        self.assertEquals(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" -d " 
                                              "'{\"id\": 1, \"name\": \"Foo\"}' http://example.com/api/v2/test")
 
     def test_post_method(self):

--- a/tests/curlcommandtest.py
+++ b/tests/curlcommandtest.py
@@ -9,8 +9,8 @@ class CurlCommandTest(TestCase):
         method = "get"
         url = "http://example.com/api/v2/test"
         data = "{\"id\": 1, \"name\": \"Foo\"}"
-
-        curlcommand = CurlCommand(url, method, data)
+        headers = u'{}'
+        curlcommand = CurlCommand(url, method, data, headers)
 
         self.assertEquals(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" -d "
                                              "'{\"id\": 1, \"name\": \"Foo\"}' http://example.com/api/v2/test")
@@ -19,8 +19,8 @@ class CurlCommandTest(TestCase):
         method = "pOsT"
         url = "http://example.com/api/post"
         data = "{\"id\": 2, \"name\": \"Bar\"}"
-
-        curlcommand = CurlCommand(url, method, data)
+        headers = u'{}'
+        curlcommand = CurlCommand(url, method, data, headers)
 
         self.assertEquals(curlcommand.get(), "curl -XPOST -H \"Content-type: application/json\" -d "
                                              "'{\"id\": 2, \"name\": \"Bar\"}' http://example.com/api/post")
@@ -29,7 +29,8 @@ class CurlCommandTest(TestCase):
         method = "get"
         url = "http://example.com/api/v2/list"
         data = ""
-        curlcommand = CurlCommand(url, method, data)
+        headers = u'{}'
+        curlcommand = CurlCommand(url, method, data, headers)
         self.assertEquals(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" "
                                              "http://example.com/api/v2/list")
 

--- a/tests/httpoperationtest.py
+++ b/tests/httpoperationtest.py
@@ -77,7 +77,7 @@ class HttpOperationTest(TestCase):
 
     def setUp(self):
         self.http_op = HttpOperation('post', 'https://server.de/', 'pet/{petId}/uploadImage', self.SAMPLE_OP_INFOS,
-                                     False)
+                                     {"X-API-Key" : "abcdef123"}, False)
 
     def test_replace_url_parameter_replaces_placeholder_in_url_with_type_value(self):
         url = self.http_op.replace_url_parameter(ReplicatorTest.SAMPLE_DEFINITION, self.http_op.url, 'petId', 'integer')
@@ -102,7 +102,7 @@ class HttpOperationTest(TestCase):
     @patch('requests.get', side_effect=mock_request_get)
     def test_execute_will_get_op_request_with_url_and_params_when_form_data_param_set(self, mock_get):
         self.http_op = HttpOperation('get', 'https://server.de/', 'pet/{petId}/uploadImage',
-                                     self.SAMPLE_OP_INFOS, False)
+                                     self.SAMPLE_OP_INFOS, {"X-API-Key" : "abcdef123"}, False)
         self.http_op.execute(ReplicatorTest.SAMPLE_DEFINITION)
         self.assertIn(mock.call(params={'status': '', 'name': ''},
                                 url='https://server.de/pet/0/uploadImage'), mock_get.call_args_list)
@@ -110,14 +110,14 @@ class HttpOperationTest(TestCase):
     @patch('requests.delete', side_effect=mock_request_delete)
     def test_execute_will_delete_op_request_with_url_only(self, mock_delete):
         self.http_op = HttpOperation('delete', 'https://server.de/', 'pet/{petId}/uploadImage',
-                                     self.SAMPLE_OP_INFOS, False)
+                                     self.SAMPLE_OP_INFOS, {"X-API-Key" : "abcdef123"}, False)
         self.http_op.execute(ReplicatorTest.SAMPLE_DEFINITION)
         self.assertIn(mock.call(url='https://server.de/pet/0/uploadImage'), mock_delete.call_args_list)
 
     @patch('requests.put', side_effect=mock_request_put)
     def test_execute_will_put_op_request_with_url_and_params_when_form_data_param_set(self, mock_put):
         self.http_op = HttpOperation('put', 'https://server.de/', 'pet/{petId}/uploadImage',
-                                     self.SAMPLE_OP_INFOS, False)
+                                     self.SAMPLE_OP_INFOS, {"X-API-Key" : "abcdef123"}, False)
         self.http_op.execute(ReplicatorTest.SAMPLE_DEFINITION)
         self.assertIn(mock.call(data={'status': '', 'name': ''},
                                 url='https://server.de/pet/0/uploadImage'), mock_put.call_args_list)

--- a/tests/httpoperationtest.py
+++ b/tests/httpoperationtest.py
@@ -5,19 +5,19 @@ from tests.replicatortest import ReplicatorTest
 from tntfuzzer.httpoperation import HttpOperation
 
 
-def mock_request_get(url, params=None):
+def mock_request_get(url, params=None, headers=None):
     pass
 
 
-def mock_request_post(url, data=None, json=None):
+def mock_request_post(url, data=None, json=None, headers=None):
     pass
 
 
-def mock_request_delete(url):
+def mock_request_delete(url, headers=None):
     pass
 
 
-def mock_request_put(url, data=None):
+def mock_request_put(url, data=None, headers=None):
     pass
 
 
@@ -96,7 +96,7 @@ class HttpOperationTest(TestCase):
     @patch('requests.post', side_effect=mock_request_post)
     def test_execute_will_post__op_request_with_params_when_form_data_param_set(self, mock_post):
         self.http_op.execute(ReplicatorTest.SAMPLE_DEFINITION)
-        self.assertIn(mock.call(data={'status': '', 'name': ''}, json=None,
+        self.assertIn(mock.call(data={'status': '', 'name': ''}, json=None, headers={"X-API-Key" : "abcdef123"},
                                 url='https://server.de/pet/0/uploadImage'), mock_post.call_args_list)
 
     @patch('requests.get', side_effect=mock_request_get)
@@ -105,19 +105,21 @@ class HttpOperationTest(TestCase):
                                      self.SAMPLE_OP_INFOS, {"X-API-Key" : "abcdef123"}, False)
         self.http_op.execute(ReplicatorTest.SAMPLE_DEFINITION)
         self.assertIn(mock.call(params={'status': '', 'name': ''},
-                                url='https://server.de/pet/0/uploadImage'), mock_get.call_args_list)
+                                url='https://server.de/pet/0/uploadImage', headers={"X-API-Key" : "abcdef123"}),
+                      mock_get.call_args_list)
 
     @patch('requests.delete', side_effect=mock_request_delete)
     def test_execute_will_delete_op_request_with_url_only(self, mock_delete):
         self.http_op = HttpOperation('delete', 'https://server.de/', 'pet/{petId}/uploadImage',
                                      self.SAMPLE_OP_INFOS, {"X-API-Key" : "abcdef123"}, False)
         self.http_op.execute(ReplicatorTest.SAMPLE_DEFINITION)
-        self.assertIn(mock.call(url='https://server.de/pet/0/uploadImage'), mock_delete.call_args_list)
+        self.assertIn(mock.call(url='https://server.de/pet/0/uploadImage', headers={"X-API-Key" : "abcdef123"}),
+                      mock_delete.call_args_list)
 
     @patch('requests.put', side_effect=mock_request_put)
     def test_execute_will_put_op_request_with_url_and_params_when_form_data_param_set(self, mock_put):
         self.http_op = HttpOperation('put', 'https://server.de/', 'pet/{petId}/uploadImage',
                                      self.SAMPLE_OP_INFOS, {"X-API-Key" : "abcdef123"}, False)
         self.http_op.execute(ReplicatorTest.SAMPLE_DEFINITION)
-        self.assertIn(mock.call(data={'status': '', 'name': ''},
+        self.assertIn(mock.call(data={'status': '', 'name': ''}, headers={"X-API-Key" : "abcdef123"},
                                 url='https://server.de/pet/0/uploadImage'), mock_put.call_args_list)

--- a/tests/httpoperationtest.py
+++ b/tests/httpoperationtest.py
@@ -77,7 +77,7 @@ class HttpOperationTest(TestCase):
 
     def setUp(self):
         self.http_op = HttpOperation('post', 'https://server.de/', 'pet/{petId}/uploadImage', self.SAMPLE_OP_INFOS,
-                                     {"X-API-Key" : "abcdef123"}, False)
+                                     {"X-API-Key": "abcdef123"}, False)
 
     def test_replace_url_parameter_replaces_placeholder_in_url_with_type_value(self):
         url = self.http_op.replace_url_parameter(ReplicatorTest.SAMPLE_DEFINITION, self.http_op.url, 'petId', 'integer')
@@ -96,30 +96,30 @@ class HttpOperationTest(TestCase):
     @patch('requests.post', side_effect=mock_request_post)
     def test_execute_will_post__op_request_with_params_when_form_data_param_set(self, mock_post):
         self.http_op.execute(ReplicatorTest.SAMPLE_DEFINITION)
-        self.assertIn(mock.call(data={'status': '', 'name': ''}, json=None, headers={"X-API-Key" : "abcdef123"},
+        self.assertIn(mock.call(data={'status': '', 'name': ''}, json=None, headers={"X-API-Key": "abcdef123"},
                                 url='https://server.de/pet/0/uploadImage'), mock_post.call_args_list)
 
     @patch('requests.get', side_effect=mock_request_get)
     def test_execute_will_get_op_request_with_url_and_params_when_form_data_param_set(self, mock_get):
         self.http_op = HttpOperation('get', 'https://server.de/', 'pet/{petId}/uploadImage',
-                                     self.SAMPLE_OP_INFOS, {"X-API-Key" : "abcdef123"}, False)
+                                     self.SAMPLE_OP_INFOS, {"X-API-Key": "abcdef123"}, False)
         self.http_op.execute(ReplicatorTest.SAMPLE_DEFINITION)
         self.assertIn(mock.call(params={'status': '', 'name': ''},
-                                url='https://server.de/pet/0/uploadImage', headers={"X-API-Key" : "abcdef123"}),
+                                url='https://server.de/pet/0/uploadImage', headers={"X-API-Key": "abcdef123"}),
                       mock_get.call_args_list)
 
     @patch('requests.delete', side_effect=mock_request_delete)
     def test_execute_will_delete_op_request_with_url_only(self, mock_delete):
         self.http_op = HttpOperation('delete', 'https://server.de/', 'pet/{petId}/uploadImage',
-                                     self.SAMPLE_OP_INFOS, {"X-API-Key" : "abcdef123"}, False)
+                                     self.SAMPLE_OP_INFOS, {"X-API-Key": "abcdef123"}, False)
         self.http_op.execute(ReplicatorTest.SAMPLE_DEFINITION)
-        self.assertIn(mock.call(url='https://server.de/pet/0/uploadImage', headers={"X-API-Key" : "abcdef123"}),
+        self.assertIn(mock.call(url='https://server.de/pet/0/uploadImage', headers={"X-API-Key": "abcdef123"}),
                       mock_delete.call_args_list)
 
     @patch('requests.put', side_effect=mock_request_put)
     def test_execute_will_put_op_request_with_url_and_params_when_form_data_param_set(self, mock_put):
         self.http_op = HttpOperation('put', 'https://server.de/', 'pet/{petId}/uploadImage',
-                                     self.SAMPLE_OP_INFOS, {"X-API-Key" : "abcdef123"}, False)
+                                     self.SAMPLE_OP_INFOS, {"X-API-Key": "abcdef123"}, False)
         self.http_op.execute(ReplicatorTest.SAMPLE_DEFINITION)
-        self.assertIn(mock.call(data={'status': '', 'name': ''}, headers={"X-API-Key" : "abcdef123"},
+        self.assertIn(mock.call(data={'status': '', 'name': ''}, headers={"X-API-Key": "abcdef123"},
                                 url='https://server.de/pet/0/uploadImage'), mock_put.call_args_list)

--- a/tntfuzzer/curlcommand.py
+++ b/tntfuzzer/curlcommand.py
@@ -1,6 +1,8 @@
 import json
 
+
 class CurlCommand:
+
     def __init__(self, url, method, data, headers):
         self.url = url
         self.method = method
@@ -12,9 +14,8 @@ class CurlCommand:
             curl_command = "curl -X" + self.method.upper() + self.generate_headers() \
                            + " " + self.url
         else:
-            curl_command = "curl -X" + self.method.upper() + self.generate_headers() + \
-                                                             " -d '" + self.data + "' " \
-                           + self.url
+            curl_command = "curl -X" + self.method.upper() + \
+                           self.generate_headers() + " -d '" + self.data + "' " + self.url
 
         return curl_command
 
@@ -29,5 +30,3 @@ class CurlCommand:
                 headers_string += "-H \"" + key + "\": \"" + value + "\""
                 headers_string += " "
         return headers_string.strip()
-
-

--- a/tntfuzzer/curlcommand.py
+++ b/tntfuzzer/curlcommand.py
@@ -10,21 +10,23 @@ class CurlCommand:
     def get(self):
         if not self.data or len(self.data) < 1:
             curl_command = "curl -X" + self.method.upper() + self.generate_headers() \
-                           + self.url
+                           + " " + self.url
         else:
             curl_command = "curl -X" + self.method.upper() + self.generate_headers() + \
-                                                             "-d '" + self.data + "' " + self.url
+                                                             " -d '" + self.data + "' " \
+                           + self.url
 
         return curl_command
 
     def generate_headers(self):
-        headers_string = " -H \"Content-type: application/json\""
+        headers_string = " -H \"Content-type: application/json\" "
         headers = json.loads(self.headers)
         if not bool(headers):
             return headers_string
         else:
             for key, value in headers.items():
-                headers_string += " -H \"" + key + "\": \"" + value + "\""
-        return headers_string.strip(" ")
+                headers_string += "-H \"" + key + "\": \"" + value + "\""
+                headers_string += " "
+        return headers_string.strip()
 
 

--- a/tntfuzzer/curlcommand.py
+++ b/tntfuzzer/curlcommand.py
@@ -1,15 +1,27 @@
 class CurlCommand:
-    def __init__(self, url, method, data):
+    def __init__(self, url, method, data, headers):
         self.url = url
         self.method = method
         self.data = data
+        self.headers = headers
 
     def get(self):
         if not self.data or len(self.data) < 1:
-            curl_command = "curl -X" + self.method.upper() + " -H \"Content-type: application/json\" " \
+            curl_command = "curl -X" + self.method.upper() + self.generate_headers() \
                            + self.url
         else:
-            curl_command = "curl -X" + self.method.upper() + " -H \"Content-type: application/json\" " \
+            curl_command = "curl -X" + self.method.upper() + self.generate_headers() + \
                                                              "-d '" + self.data + "' " + self.url
 
         return curl_command
+
+    def generate_headers(self):
+        headers_string = " -H \"Content-type: application/json\" "
+        if not bool(self.headers):
+            return headers_string
+        else:
+            for key in self.headers:
+                headers_string + " -H \"" + key + ":\"" + self.headers[key] + "\""
+        return headers_string
+
+

--- a/tntfuzzer/curlcommand.py
+++ b/tntfuzzer/curlcommand.py
@@ -19,11 +19,12 @@ class CurlCommand:
         return curl_command
 
     def generate_headers(self):
-        headers_string = " -H \"Content-type: application/json\" "
+        headers_string = " -H \"Content-type: application/json\""
         headers = json.loads(self.headers)
         if not bool(headers):
             return headers_string
         else:
+            headers_string += " "
             for key, value in headers.items():
                 headers_string += "-H \"" + key + "\": \"" + value + "\""
                 headers_string += " "

--- a/tntfuzzer/curlcommand.py
+++ b/tntfuzzer/curlcommand.py
@@ -1,3 +1,5 @@
+import json
+
 class CurlCommand:
     def __init__(self, url, method, data, headers):
         self.url = url
@@ -16,12 +18,13 @@ class CurlCommand:
         return curl_command
 
     def generate_headers(self):
-        headers_string = " -H \"Content-type: application/json\" "
-        if not bool(self.headers):
+        headers_string = " -H \"Content-type: application/json\""
+        headers = json.loads(self.headers)
+        if not bool(headers):
             return headers_string
         else:
-            for key in self.headers:
-                headers_string + " -H \"" + key + ":\"" + self.headers[key] + "\""
-        return headers_string
+            for key, value in headers.items():
+                headers_string += " -H \"" + key + "\": \"" + value + "\""
+        return headers_string.strip(" ")
 
 

--- a/tntfuzzer/httpoperation.py
+++ b/tntfuzzer/httpoperation.py
@@ -9,13 +9,14 @@ from replicator import Replicator
 
 
 class HttpOperation:
-    def __init__(self, op_code, host_basepath, path, op_infos, use_fuzzing=True):
+    def __init__(self, op_code, host_basepath, path, op_infos, headers, use_fuzzing=True):
         self.op_code = op_code
         self.url = host_basepath + path
         self.op_infos = op_infos
         self.use_fuzzing = use_fuzzing
         self.fuzzer = None
         self.request_body = None
+        self.headers = headers
 
     def fuzz(self, json_str):
         if self.use_fuzzing is False:

--- a/tntfuzzer/httpoperation.py
+++ b/tntfuzzer/httpoperation.py
@@ -50,18 +50,18 @@ class HttpOperation:
 
         if self.op_code == 'post':
             if bool(form_data):
-                response = requests.post(url=url, data=form_data, json=None)
+                response = requests.post(url=url, data=form_data, json=None, headers=self.headers)
             else:
-                response = requests.post(url=url, data=None, json=self.request_body)
+                response = requests.post(url=url, data=None, json=self.request_body, headers=self.headers)
 
         elif self.op_code == 'get':
-            response = requests.get(url=url, params=form_data)
+            response = requests.get(url=url, params=form_data, headers=self.headers)
 
         elif self.op_code == 'delete':
-            response = requests.delete(url=url)
+            response = requests.delete(url=url, headers=self.headers)
 
         elif self.op_code == 'put':
-            response = requests.put(url=url, data=form_data)
+            response = requests.put(url=url, data=form_data, headers=self.headers)
 
         else:
             response = None

--- a/tntfuzzer/tntfuzzer.py
+++ b/tntfuzzer/tntfuzzer.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 
 import termcolor
 from bravado.client import SwaggerClient
@@ -16,9 +17,10 @@ from strutils import StrUtils
 
 class TntFuzzer:
 
-    def __init__(self, url, iterations, log_unexpected_errors_only):
+    def __init__(self, url, iterations, headers, log_unexpected_errors_only):
         self.url = url
         self.iterations = iterations
+        self.headers = headers
         self.log_unexpected_errors_only = log_unexpected_errors_only
 
     def start(self):
@@ -62,7 +64,7 @@ class TntFuzzer:
 
                 for op_code in path.keys():
                     operation = HttpOperation(op_code, protocol + '://' + host_basepath, path_key,
-                                              op_infos=path[op_code], use_fuzzing=True)
+                                              op_infos=path[op_code], use_fuzzing=True, headers=self.headers)
 
                     for x in range(self.iterations):
                         response = operation.execute(type_definitions)
@@ -110,12 +112,16 @@ def main():
                         help='If set, all responses are logged. The expected responses and the '
                              'unexpected ones. Per default only unexpected responses are logged.')
 
+    parser.add_argument('--headers', type=json.loads,
+                        help='Send custom http headers for Cookies or api keys e.g. { \"X-API-Key\": \"abcdef12345\", \"user-agent\": \"tntfuzzer\" }')
+
     args = vars(parser.parse_args())
 
     if args['url'] is None:
         parser.print_usage()
     else:
-        tnt = TntFuzzer(url=args['url'], iterations=args['iterations'], log_unexpected_errors_only=not args['log_all'])
+        tnt = TntFuzzer(url=args['url'], iterations=args['iterations'], headers=args['headers'],
+                        log_unexpected_errors_only=not args['log_all'])
         tnt.start()
 
 

--- a/tntfuzzer/tntfuzzer.py
+++ b/tntfuzzer/tntfuzzer.py
@@ -113,7 +113,8 @@ def main():
                              'unexpected ones. Per default only unexpected responses are logged.')
 
     parser.add_argument('--headers', type=json.loads,
-                        help='Send custom http headers for Cookies or api keys e.g. { \"X-API-Key\": \"abcdef12345\", \"user-agent\": \"tntfuzzer\" }')
+                        help='Send custom http headers for Cookies or api keys e.g. { \"X-API-Key\": \"abcdef12345\", '
+                             '\"user-agent\": \"tntfuzzer\" }')
 
     args = vars(parser.parse_args())
 


### PR DESCRIPTION
## Purpose
According to #19 this PR adds the possibility to send an api key to avoid http status 403.

## Goals
Pass api key via http header to the rest api. 

## Approach
The api keys can be defined as a command line argument and will be set in the http request.

## Ran tests?
Yes

