### PR TITLE
Fix CVE-2018-18074 in requests dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ GitPython==2.1.11
 gramfuzz==1.2.0
 idna==2.7
 PyJFuzz==1.1.0
-requests==2.19.1
+requests>=2.20.0
 smmap2==2.0.4
 termcolor==1.1.0
 urllib3==1.23


### PR DESCRIPTION
## Purpose
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.

## Goals
Fix CVE-2018-18074

## Approach
Upgrade requests to version 2.20.0 or later. 

## Added tests?
No

