### PR TITLE
Add swagger schema version validation on startup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - pip install -r requirements-dev.txt
 # command to run tests
 script:
-  - cd tntfuzzer && nosetests tests/core/*.py tests/utils/*.py
+  - cd tntfuzzer && nosetests tests/core/*.py tests/utils/*.py tests/*.py
   - pycodestyle --max-line-length=120 ./tests/core/*.py
   - pycodestyle --max-line-length=120 ./tests/utils/*.py
   - pycodestyle --max-line-length=120 --ignore=W605,W504 ./*.py

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ Run software tests using the following command:
 
 ```
 $ cd tntfuzzer
-$ nosetests  tests/core/*.py tests/utils/*.py
+$ nosetests  tests/core/*.py tests/utils/*.py tests/*.py
 ........................
 ----------------------------------------------------------------------
-Ran 37 tests in 0.028s
+Ran 41 tests in 0.028s
 
 OK
 ```

--- a/tntfuzzer/tests/tntfuzzertest.py
+++ b/tntfuzzer/tests/tntfuzzertest.py
@@ -1,0 +1,50 @@
+from unittest import TestCase
+
+from tntfuzzer import TntFuzzer, SchemaException
+
+
+def mock_exit(value):
+    pass
+
+
+def mock_get_swagger_spec(url):
+    return {}
+
+
+def mock_get_swagger_spec_version_1(url):
+    return {'swagger': '1.0'}
+
+
+def mock_get_swagger_spec_version_2(url):
+    return {'swagger': '2.0', 'basePath': '', 'paths': {}, 'definitions': {}}
+
+
+def mock_get_swagger_spec_version_3(url):
+    return {'swagger': '3.0'}
+
+
+class TntFuzzerTest(TestCase):
+
+    def test_tntfuzzer_throws_exception_when_version_not_stated_in_schema(self):
+        fuzzer = TntFuzzer('http://notexistant/swagger.json', 1, None, True, 20, True)
+        fuzzer.get_swagger_spec = mock_get_swagger_spec
+
+        self.assertRaises(SchemaException, fuzzer.start)
+
+    def test_tntfuzzer_throws_exception_when_swagger_version_1_used(self):
+        fuzzer = TntFuzzer('http://notexistant/swagger.json', 1, None, True, 20, True)
+        fuzzer.get_swagger_spec = mock_get_swagger_spec_version_1
+
+        self.assertRaises(SchemaException, fuzzer.start)
+
+    def test_tntfuzzer_throws_exception_when_swagger_version_3_used(self):
+        fuzzer = TntFuzzer('http://notexistant/swagger.json', 1, None, True, 20, True)
+        fuzzer.get_swagger_spec = mock_get_swagger_spec_version_3
+
+        self.assertRaises(SchemaException, fuzzer.start)
+
+    def test_tntfuzzer_starts_fuzzing_when_version_2_used(self):
+        fuzzer = TntFuzzer('http://notexistant/swagger.json', 1, None, True, 20, True)
+        fuzzer.get_swagger_spec = mock_get_swagger_spec_version_2
+
+        self.assertTrue(fuzzer.start())


### PR DESCRIPTION
## Purpose
Swagger specification other than version 2 are not compatible. Enhance error handling.

## Goals
We need more detailed errors stated on startup and in the logs.

## Approach
Add additional exception handling concerning specification version.

## Added tests?
YES

