### PR TITLE
Add enum data type

### DIFF
--- a/tntfuzzer/core/replicator.py
+++ b/tntfuzzer/core/replicator.py
@@ -67,6 +67,8 @@ class Replicator:
         for prop in object_schema['properties']:
             if 'type' in object_schema['properties'][prop]:
                 prop_type = object_schema['properties'][prop]['type']
+            elif 'enum' in object_schema['properties']:
+                prop_type = 'enum'
             else:
                 prop_type = object_schema['properties'][prop]['$ref']
 
@@ -77,6 +79,9 @@ class Replicator:
                     array_type = object_schema['properties'][prop]['items']['type']
                 object_instance[prop] = list()
                 object_instance[prop].append(self.create_init_value(array_type))
+            elif prop_type == 'enum':
+                object_instance[prop] = list()
+                object_instance[prop].append(object_schema['properties'][prop])
             else:
                 object_instance[prop] = self.create_init_value(prop_type)
 

--- a/tntfuzzer/tests/core/replicatortest.py
+++ b/tntfuzzer/tests/core/replicatortest.py
@@ -57,6 +57,12 @@ class ReplicatorTest(TestCase):
                 "name": "Category"
             }
         },
+        "Schema": {
+            "type": "string",
+            "properties": {
+                "enum": ["asc", "desc"]
+            },
+        },
         "User": {
             "type": "object",
             "properties": {
@@ -231,3 +237,11 @@ class ReplicatorTest(TestCase):
 
     def test_as_json_returns_created_object_as_json(self):
         self.assertEqual(self.replicator.as_json('#/definitions/Tag'), '{"id": 0, "name": ""}')
+
+    def test_as_json_returns_enum(self):
+        self.replicator = Replicator(definitions=self.SAMPLE_DEFINITION,
+                                     use_string_pattern=True,
+                                     init_rand_values=False)
+        result = self.replicator.as_json('#/definitions/Schema')
+        self.assertIsNotNone(result)
+        self.assertEqual(result, '{"enum": [["asc", "desc"]]}')


### PR DESCRIPTION
## Purpose
TnT-Fuzzer does not support `enum` (https://swagger.io/docs/specification/data-models/enums/) at the moment 

## Goals
Fix bug in the replicatorr to support `enum` data types.

## Approach
Add `enum` handling to the `object_schema` handler method

## Added tests?
Yes

