### PR TITLE
Add error handling on connect

### DIFF
--- a/tntfuzzer/tntfuzzer.py
+++ b/tntfuzzer/tntfuzzer.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import requests
 import termcolor
+import sys
 
 from urllib.parse import urlparse
 
@@ -38,8 +39,11 @@ class TntFuzzer:
         host = None
         basePath = None
 
-        spec = self.get_swagger_spec(self.url)
-        specURL = urlparse(self.url)
+        try:
+            spec = self.get_swagger_spec(self.url)
+            specURL = urlparse(self.url)
+        except json.JSONDecodeError:
+            error_cant_connect()
 
         if 'swagger' not in spec:
             self.log_operation(None, self.url,
@@ -129,6 +133,11 @@ class TntFuzzer:
 
     def get_swagger_spec(self, url):
         return json.loads(requests.get(url=url).text)
+
+
+def error_cant_connect():
+    print('Unable to get swagger file :-(')
+    sys.exit(1)
 
 
 def main():


### PR DESCRIPTION
## Purpose
the fuzzer raises unreadable error messages if the given url is not available.

## Goals
provide a pretty error message and an error code

## Approach
exit the program with an error code if `specURL` is not defined.

## Added tests?
No

