### PR TITLE
Add support for patch requests in http operation

### DIFF
--- a/tntfuzzer/core/httpoperation.py
+++ b/tntfuzzer/core/httpoperation.py
@@ -66,6 +66,9 @@ class HttpOperation:
         elif self.op_code == 'put':
             response = requests.put(url=url, data=form_data, headers=self.headers)
 
+        elif self.op_code == 'patch':
+            response = requests.patch(url=url, data=form_data, headers=self.headers)
+
         else:
             response = None
 


### PR DESCRIPTION
## Purpose
Fix crashes concerning patch routes found in swagger.json.

## Goals
Instead of crash with stacktrace, execute new patch http operation as expected be swagger.json input.

## Approach
Add new patch condition in http operation.

## Added tests?
No

