### PR TITLE
Patch CVE-2019-11324

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ PyJFuzz==1.1.0
 requests>=2.20.0
 smmap2==2.0.4
 termcolor==1.1.0
-urllib3==1.23
+urllib3>=1.24.2


### PR DESCRIPTION
## Purpose
The urllib3 library before 1.24.2 for Python mishandles certain cases where the desired set of CA certificates is different from the OS store of CA certificates, which results in SSL connections succeeding in situations where a verification failure is the correct outcome. This is related to use of the ssl_context, ca_certs, or ca_certs_dir argument.

## Goals
Fix CVE-2019-11324

## Approach
Upgrade urllib3 to version 1.24.2 or later.

## Added tests?
No

