### PR TITLE
Also use headers when requesting swagger file (because of auth)

### DIFF
--- a/tntfuzzer/core/curlcommand.py
+++ b/tntfuzzer/core/curlcommand.py
@@ -11,10 +11,10 @@ class CurlCommand:
 
     def get(self):
         if not self.data or len(self.data) < 1:
-            curl_command = "curl -X" + self.method.upper() + self.generate_headers() \
+            curl_command = "curl -X" + self.method.upper() + " " + self.generate_headers() \
                            + " " + self.url
         else:
-            curl_command = "curl -X" + self.method.upper() + \
+            curl_command = "curl -X" + self.method.upper() + " " + \
                            self.generate_headers() + " -d '" + self.data + "' " + self.url
 
         return curl_command

--- a/tntfuzzer/core/curlcommand.py
+++ b/tntfuzzer/core/curlcommand.py
@@ -23,12 +23,9 @@ class CurlCommand:
         headers_string = " -H \"Content-type: application/json\""
 
         if self.headers is not None:
-            headers = json.loads(self.headers)
-            if not bool(headers):
-                return headers_string
-            else:
+            # self.headers is always a dict, because argparse has type=json.loads
+            headers_string += " "
+            for key, value in self.headers.items():
+                headers_string += "-H \"" + key + "\": \"" + value + "\""
                 headers_string += " "
-                for key, value in headers.items():
-                    headers_string += "-H \"" + key + "\": \"" + value + "\""
-                    headers_string += " "
         return headers_string.strip()

--- a/tntfuzzer/tests/core/curlcommandtest.py
+++ b/tntfuzzer/tests/core/curlcommandtest.py
@@ -1,3 +1,4 @@
+import json
 from unittest import TestCase
 
 from core.curlcommand import CurlCommand
@@ -9,7 +10,7 @@ class CurlCommandTest(TestCase):
         method = "get"
         url = "http://example.com/api/v2/test"
         data = "{\"id\": 1, \"name\": \"Foo\"}"
-        headers = u'{}'
+        headers = json.loads('{}')
         curlcommand = CurlCommand(url, method, data, headers)
 
         self.assertEquals(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" -d "
@@ -19,7 +20,7 @@ class CurlCommandTest(TestCase):
         method = "pOsT"
         url = "http://example.com/api/post"
         data = "{\"id\": 2, \"name\": \"Bar\"}"
-        headers = u'{}'
+        headers = json.loads('{}')
         curlcommand = CurlCommand(url, method, data, headers)
 
         self.assertEquals(curlcommand.get(), "curl -XPOST -H \"Content-type: application/json\" -d "
@@ -29,7 +30,7 @@ class CurlCommandTest(TestCase):
         method = "get"
         url = "http://example.com/api/v2/list"
         data = ""
-        headers = u'{}'
+        headers = json.loads('{}')
         curlcommand = CurlCommand(url, method, data, headers)
         self.assertEquals(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" "
                                              "http://example.com/api/v2/list")
@@ -38,7 +39,7 @@ class CurlCommandTest(TestCase):
         method = "get"
         url = "http://example.com/api/v2/list"
         data = ""
-        headers = '{ \"X-API-Key\": \"abcdef12345\", \"user-agent\": \"tntfuzzer\" }'
+        headers = json.loads('{ \"X-API-Key\": \"abcdef12345\", \"user-agent\": \"tntfuzzer\" }')
         expected_result = u'-H \"Content-type: application/json\" -H \"X-API-Key\": \"abcdef12345\" ' \
                           u'-H \"user-agent\": \"tntfuzzer\"'
         curlcommand = CurlCommand(url, method, data, headers)

--- a/tntfuzzer/tntfuzzer.py
+++ b/tntfuzzer/tntfuzzer.py
@@ -134,6 +134,7 @@ class TntFuzzer:
     def get_swagger_spec(self, url):
         return json.loads(requests.get(url=url, headers=self.headers).text)
 
+
 def error_cant_connect():
     print('Unable to get swagger file :-(')
     sys.exit(1)

--- a/tntfuzzer/tntfuzzer.py
+++ b/tntfuzzer/tntfuzzer.py
@@ -132,8 +132,7 @@ class TntFuzzer:
                 StrUtils.print_log_row(op_code, url, status_code, documented_reason, body, curlcommand)
 
     def get_swagger_spec(self, url):
-        return json.loads(requests.get(url=url).text)
-
+        return json.loads(requests.get(url=url, headers=self.headers).text)
 
 def error_cant_connect():
     print('Unable to get swagger file :-(')


### PR DESCRIPTION
## Purpose
When initially retrieving the swagger file, headers were not sent. This leads to problems, if authentication happens via headers.

## Approach
Added headers get_swagger_spec() and improved handling of headers in generate_headers() of CurlCommand

## Added tests?
No

