### PR TITLE
New Features: Ignore self-signed cert and change host/basePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,15 @@ Per default only responses that are not documented in your Service's OpenAPI spe
 undocumented errors are logged. If you want all fuzz responses to be logged, you have to specify that by
 setting the **--log_all** parameter.
 
+If you want to connect to servers using self-signed certificates, use the **--ignore-cert-errors**.
+
+Sometimes an OpenAPI file will contain an invalid host name, or point to the wrong server. If you use the **--host**
+option you can override this without making a local copy of the file. Same happens with **--basepath** that let you
+specify a different basepath for the API. 
+
 So following example run will fuzz every API call specified in the swagger.json with 100 permutations each. All
 responses received from the server are logged:
+
 ```
 tntfuzzer --url http://example.com:8080/v2/swagger.json --iterations 100 --log_all
 ```

--- a/tntfuzzer/core/curlcommand.py
+++ b/tntfuzzer/core/curlcommand.py
@@ -10,7 +10,7 @@ class CurlCommand:
         self.headers = headers
 
         if ignore_tls:
-            self.ignore_tls = "-k " # short for --insecure
+            self.ignore_tls = "-k "  # short for --insecure
         else:
             self.ignore_tls = ""
 

--- a/tntfuzzer/core/curlcommand.py
+++ b/tntfuzzer/core/curlcommand.py
@@ -3,18 +3,23 @@ import json
 
 class CurlCommand:
 
-    def __init__(self, url, method, data, headers):
+    def __init__(self, url, method, data, headers, ignore_tls=False):
         self.url = url
         self.method = method
         self.data = data
         self.headers = headers
 
+        if ignore_tls:
+            self.ignore_tls = "-k " # short for --insecure
+        else:
+            self.ignore_tls = ""
+
     def get(self):
         if not self.data or len(self.data) < 1:
-            curl_command = "curl -X" + self.method.upper() + " " + self.generate_headers() \
+            curl_command = "curl " + self.ignore_tls + "-X" + self.method.upper() + " " + self.generate_headers() \
                            + " " + self.url
         else:
-            curl_command = "curl -X" + self.method.upper() + " " + \
+            curl_command = "curl " + self.ignore_tls + "-X" + self.method.upper() + " " + \
                            self.generate_headers() + " -d '" + self.data + "' " + self.url
 
         return curl_command

--- a/tntfuzzer/core/httpoperation.py
+++ b/tntfuzzer/core/httpoperation.py
@@ -9,7 +9,7 @@ from pyjfuzz.core.pjf_factory import PJFFactory
 
 
 class HttpOperation:
-    def __init__(self, op_code, host_basepath, path, op_infos, headers, replicator, use_fuzzing=True):
+    def __init__(self, op_code, host_basepath, path, op_infos, headers, replicator, use_fuzzing=True, ignore_tls=False):
         self.op_code = op_code
         self.url = host_basepath + path
         self.op_infos = op_infos
@@ -18,6 +18,7 @@ class HttpOperation:
         self.fuzzer = None
         self.request_body = None
         self.headers = headers
+        self.ignore_tls = ignore_tls
         self.random = Random()
 
     def fuzz(self, json_str):
@@ -32,6 +33,7 @@ class HttpOperation:
     def execute(self):
         url = self.url
         form_data = dict()
+        verify_tls = not self.ignore_tls # ignore_tls defaults to False, but verify=False will disable TLS verification
 
         if 'parameters' in self.op_infos:
             for parameter in self.op_infos['parameters']:
@@ -53,21 +55,21 @@ class HttpOperation:
 
         if self.op_code == 'post':
             if bool(form_data):
-                response = requests.post(url=url, data=form_data, json=None, headers=self.headers)
+                response = requests.post(url=url, data=form_data, json=None, headers=self.headers, verify=verify_tls)
             else:
-                response = requests.post(url=url, data=None, json=self.request_body, headers=self.headers)
+                response = requests.post(url=url, data=None, json=self.request_body, headers=self.headers, verify=verify_tls)
 
         elif self.op_code == 'get':
-            response = requests.get(url=url, params=form_data, headers=self.headers)
+            response = requests.get(url=url, params=form_data, headers=self.headers, verify=verify_tls)
 
         elif self.op_code == 'delete':
-            response = requests.delete(url=url, headers=self.headers)
+            response = requests.delete(url=url, headers=self.headers, verify=verify_tls)
 
         elif self.op_code == 'put':
-            response = requests.put(url=url, data=form_data, headers=self.headers)
+            response = requests.put(url=url, data=form_data, headers=self.headers, verify=verify_tls)
 
         elif self.op_code == 'patch':
-            response = requests.patch(url=url, data=form_data, headers=self.headers)
+            response = requests.patch(url=url, data=form_data, headers=self.headers, verify=verify_tls)
 
         else:
             response = None

--- a/tntfuzzer/core/httpoperation.py
+++ b/tntfuzzer/core/httpoperation.py
@@ -33,7 +33,7 @@ class HttpOperation:
     def execute(self):
         url = self.url
         form_data = dict()
-        verify_tls = not self.ignore_tls # ignore_tls defaults to False, but verify=False will disable TLS verification
+        verify_tls = not self.ignore_tls  # ignore_tls defaults to False, but verify=False will disable TLS verification
 
         if 'parameters' in self.op_infos:
             for parameter in self.op_infos['parameters']:
@@ -57,7 +57,8 @@ class HttpOperation:
             if bool(form_data):
                 response = requests.post(url=url, data=form_data, json=None, headers=self.headers, verify=verify_tls)
             else:
-                response = requests.post(url=url, data=None, json=self.request_body, headers=self.headers, verify=verify_tls)
+                response = requests.post(url=url, data=None, json=self.request_body, headers=self.headers,
+                                         verify=verify_tls)
 
         elif self.op_code == 'get':
             response = requests.get(url=url, params=form_data, headers=self.headers, verify=verify_tls)

--- a/tntfuzzer/tests/core/httpoperationtest.py
+++ b/tntfuzzer/tests/core/httpoperationtest.py
@@ -151,7 +151,8 @@ class HttpOperationTest(TestCase):
                                                        self.SAMPLE_OP_INFOS, {"X-API-Key": "abcdef123"})
         self.http_op.execute()
         self.assertIn(mock.call(params={'status': '', 'name': ''},
-                                url='https://server.de/pet/0/uploadImage', headers={"X-API-Key": "abcdef123"}, verify=False),
+                                url='https://server.de/pet/0/uploadImage',
+                                headers={"X-API-Key": "abcdef123"}, verify=False),
                       mock_get.call_args_list)
 
     @patch('requests.delete', side_effect=mock_request_delete)
@@ -159,7 +160,8 @@ class HttpOperationTest(TestCase):
         self.http_op = create_http_op_with_random_mock('delete', 'https://server.de/', 'pet/{petId}/uploadImage',
                                                        self.SAMPLE_OP_INFOS, {"X-API-Key": "abcdef123"})
         self.http_op.execute()
-        self.assertIn(mock.call(url='https://server.de/pet/0/uploadImage', headers={"X-API-Key": "abcdef123"}, verify=False),
+        self.assertIn(mock.call(url='https://server.de/pet/0/uploadImage',
+                                headers={"X-API-Key": "abcdef123"}, verify=False),
                       mock_delete.call_args_list)
 
     @patch('requests.put', side_effect=mock_request_put)

--- a/tntfuzzer/tntfuzzer.py
+++ b/tntfuzzer/tntfuzzer.py
@@ -21,15 +21,15 @@ class SchemaException(Exception):
 
 class TntFuzzer:
 
-    def __init__(self, url, iterations, headers, log_unexpected_errors_only, 
-                    max_string_length, use_string_pattern, ignore_tls=False, host=None, basepath=None):
+    def __init__(self, url, iterations, headers, log_unexpected_errors_only,
+                 max_string_length, use_string_pattern, ignore_tls=False, host=None, basepath=None):
         self.url = url
         self.iterations = iterations
         self.headers = headers
         self.log_unexpected_errors_only = log_unexpected_errors_only
         self.max_string_length = max_string_length
         self.use_string_pattern = use_string_pattern
-        self.ignore_tls = ignore_tls        
+        self.ignore_tls = ignore_tls
         self.host = host
         self.basepath = basepath
 
@@ -125,7 +125,8 @@ class TntFuzzer:
                         response = operation.execute()
                         validator = ResultValidator()
                         log = validator.evaluate(response, path[op_code]['responses'], self.log_unexpected_errors_only)
-                        curlcommand = CurlCommand(response.url, operation.op_code, operation.request_body, self.headers, self.ignore_tls)
+                        curlcommand = CurlCommand(response.url, operation.op_code, operation.request_body, self.headers,
+                                                  self.ignore_tls)
 
                         # log to screen for now
                         self.log_operation(operation.op_code, response.url, log, curlcommand)
@@ -144,7 +145,7 @@ class TntFuzzer:
                 StrUtils.print_log_row(op_code, url, status_code, documented_reason, body, curlcommand)
 
     def get_swagger_spec(self, url):
-        verify_tls = not self.ignore_tls # ignore_tls defaults to False, but verify=False will disable TLS verification
+        verify_tls = not self.ignore_tls  # ignore_tls defaults to False, but verify=False will disable TLS verification
         return json.loads(requests.get(url=url, headers=self.headers, verify=verify_tls).text)
 
 
@@ -158,7 +159,8 @@ def main():
     print(termcolor.colored(r'\__    ___/__\__    ___/     \_   _____/_ __________________ ___________ ', color='red'))
     print(termcolor.colored(r'  |    | /    \|    |  ______ |    __)|  |  \___   /\___   // __ \_  __ \\', color='red'))
     print(termcolor.colored(r'  |    ||   |  \    | /_____/ |     \ |  |  //    /  /    /\  ___/|  | \/', color='red'))
-    print(termcolor.colored(r'  |____||___|  /____|         \___  / |____//_____ \/_____ \\\\___  >__|   ', color='red'))
+    print(termcolor.colored(r'  |____||___|  /____|         \___  / |____//_____ \/_____ \\\\___  >__|   ',
+                            color='red'))
     print(termcolor.colored(r'    Dynamite ', 'green') + termcolor.colored(r'\/', 'red') +
           termcolor.colored(r' for your API!', 'green') +
           termcolor.colored(r'     \/              \/      \/    \/    ', 'red') +
@@ -189,7 +191,7 @@ def main():
 
     parser.add_argument('--max-random-string-len', dest='max-random-string-len', type=int, default=200,
                         help='The maximum length of generated strings.')
-    
+
     parser.add_argument('--ignore-cert-errors', dest='ignore-tls', action='store_true', default=False,
                         help='Ignore TLS errors, like self-signed certificates.')
 
@@ -206,7 +208,7 @@ def main():
     else:
         tnt = TntFuzzer(url=args['url'], iterations=args['iterations'], headers=args['headers'],
                         log_unexpected_errors_only=not args['log_all'], use_string_pattern=args['string-patterns'],
-                        max_string_length=args['max-random-string-len'], ignore_tls=args["ignore-tls"], 
+                        max_string_length=args['max-random-string-len'], ignore_tls=args["ignore-tls"],
                         host=args["host"], basepath=args["basepath"])
         try:
             tnt.start()

--- a/tntfuzzer/tntfuzzer.py
+++ b/tntfuzzer/tntfuzzer.py
@@ -2,17 +2,17 @@ import argparse
 import json
 import requests
 import termcolor
+import urllib3
 import sys
-
-from urllib.parse import urlparse
 
 from core.curlcommand import CurlCommand
 from core.httpoperation import HttpOperation
 from core.resultvalidatior import ResultValidator
 from core.replicator import Replicator
 from utils.strutils import StrUtils
+from urllib.parse import urlparse
 
-version = "2.2.0"
+version = "2.3.0"
 
 
 class SchemaException(Exception):
@@ -21,13 +21,21 @@ class SchemaException(Exception):
 
 class TntFuzzer:
 
-    def __init__(self, url, iterations, headers, log_unexpected_errors_only, max_string_length, use_string_pattern):
+    def __init__(self, url, iterations, headers, log_unexpected_errors_only, 
+                    max_string_length, use_string_pattern, ignore_tls=False, host=None, basepath=None):
         self.url = url
         self.iterations = iterations
         self.headers = headers
         self.log_unexpected_errors_only = log_unexpected_errors_only
         self.max_string_length = max_string_length
         self.use_string_pattern = use_string_pattern
+        self.ignore_tls = ignore_tls        
+        self.host = host
+        self.basepath = basepath
+
+        if self.ignore_tls:
+            # removes warnings for insecure connections
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     def start(self):
         print('Fetching open API from: ' + self.url)
@@ -74,7 +82,9 @@ class TntFuzzer:
                                    "documented_reason": "Specification: no schemes entry, fallback to spec URL scheme",
                                    "body": "Specification: host entry not present in Swagger spec"}, '')
 
-        if 'host' in spec:
+        if self.host:
+            host = self.host
+        elif 'host' in spec:
             host = spec['host']
         else:
             host = specURL.netloc
@@ -94,7 +104,9 @@ class TntFuzzer:
                                    "body": "Specification Error: basePath entry missing from Swagger spec"
                                }, '')
             raise SchemaException
-        host_basepath = host + spec['basePath']
+        basePath = self.basepath if self.basepath else spec['basePath']
+        host_basepath = host + basePath
+
         paths = spec['paths']
         type_definitions = spec['definitions']
         # the specifcation can list multiple schemes (http, https, ws, wss) - all should be tested.
@@ -107,13 +119,13 @@ class TntFuzzer:
                 for op_code in path.keys():
                     operation = HttpOperation(op_code, protocol + '://' + host_basepath, path_key,
                                               replicator=replicator, op_infos=path[op_code], use_fuzzing=True,
-                                              headers=self.headers)
+                                              headers=self.headers, ignore_tls=self.ignore_tls)
 
-                    for x in range(self.iterations):
+                    for _ in range(self.iterations):
                         response = operation.execute()
                         validator = ResultValidator()
                         log = validator.evaluate(response, path[op_code]['responses'], self.log_unexpected_errors_only)
-                        curlcommand = CurlCommand(response.url, operation.op_code, operation.request_body, self.headers)
+                        curlcommand = CurlCommand(response.url, operation.op_code, operation.request_body, self.headers, self.ignore_tls)
 
                         # log to screen for now
                         self.log_operation(operation.op_code, response.url, log, curlcommand)
@@ -132,7 +144,8 @@ class TntFuzzer:
                 StrUtils.print_log_row(op_code, url, status_code, documented_reason, body, curlcommand)
 
     def get_swagger_spec(self, url):
-        return json.loads(requests.get(url=url, headers=self.headers).text)
+        verify_tls = not self.ignore_tls # ignore_tls defaults to False, but verify=False will disable TLS verification
+        return json.loads(requests.get(url=url, headers=self.headers, verify=verify_tls).text)
 
 
 def error_cant_connect():
@@ -141,15 +154,15 @@ def error_cant_connect():
 
 
 def main():
-    print(termcolor.colored('___________  ___________     ___________', color='red'))
-    print(termcolor.colored('\__    ___/__\__    ___/     \_   _____/_ __________________ ___________ ', color='red'))
-    print(termcolor.colored('  |    | /    \|    |  ______ |    __)|  |  \___   /\___   // __ \_  __ \\', color='red'))
-    print(termcolor.colored('  |    ||   |  \    | /_____/ |     \ |  |  //    /  /    /\  ___/|  | \/', color='red'))
-    print(termcolor.colored('  |____||___|  /____|         \___  / |____//_____ \/_____ \\\\___  >__|   ', color='red'))
-    print(termcolor.colored('    Dynamite ', 'green') + termcolor.colored('\/', 'red') +
-          termcolor.colored(' for your API!', 'green') +
-          termcolor.colored('     \/              \/      \/    \/    ', 'red') +
-          termcolor.colored('   v', 'green') + termcolor.colored(version, 'blue'))
+    print(termcolor.colored(r'___________  ___________     ___________', color='red'))
+    print(termcolor.colored(r'\__    ___/__\__    ___/     \_   _____/_ __________________ ___________ ', color='red'))
+    print(termcolor.colored(r'  |    | /    \|    |  ______ |    __)|  |  \___   /\___   // __ \_  __ \\', color='red'))
+    print(termcolor.colored(r'  |    ||   |  \    | /_____/ |     \ |  |  //    /  /    /\  ___/|  | \/', color='red'))
+    print(termcolor.colored(r'  |____||___|  /____|         \___  / |____//_____ \/_____ \\\\___  >__|   ', color='red'))
+    print(termcolor.colored(r'    Dynamite ', 'green') + termcolor.colored(r'\/', 'red') +
+          termcolor.colored(r' for your API!', 'green') +
+          termcolor.colored(r'     \/              \/      \/    \/    ', 'red') +
+          termcolor.colored(r'   v', 'green') + termcolor.colored(version, 'blue'))
     print('')
 
     parser = argparse.ArgumentParser()
@@ -176,6 +189,15 @@ def main():
 
     parser.add_argument('--max-random-string-len', dest='max-random-string-len', type=int, default=200,
                         help='The maximum length of generated strings.')
+    
+    parser.add_argument('--ignore-cert-errors', dest='ignore-tls', action='store_true', default=False,
+                        help='Ignore TLS errors, like self-signed certificates.')
+
+    parser.add_argument('--host', type=str,
+                        help='Overrides the API host specified within the swagger file.')
+
+    parser.add_argument('--basepath', type=str,
+                        help='Overrides the API basePath specified within the swagger file.')
 
     args = vars(parser.parse_args())
 
@@ -184,7 +206,8 @@ def main():
     else:
         tnt = TntFuzzer(url=args['url'], iterations=args['iterations'], headers=args['headers'],
                         log_unexpected_errors_only=not args['log_all'], use_string_pattern=args['string-patterns'],
-                        max_string_length=args['max-random-string-len'])
+                        max_string_length=args['max-random-string-len'], ignore_tls=args["ignore-tls"], 
+                        host=args["host"], basepath=args["basepath"])
         try:
             tnt.start()
         except SchemaException:


### PR DESCRIPTION
## Purpose
For my workflow I needed to accept self-signed certs and be able to specify different host/basepath than then one specified on the Swagger file.

## Goals
Adds three new options:

- --ignore-cert-errors
- --host
- --basepath

## Approach
Added options and modify tests so they accept/check the new parameters. All parameters are keep as previous version by default and nothing should change with current deployments, that should not be impacted when upgrading.

## Added tests?
No, modified current tests.

