### PR TITLE
Bugfix/#39 1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests>=2.20.0
 smmap2==2.0.4
 termcolor==1.1.0
 urllib3>=1.24.2
+randomdict==0.2.0

--- a/tntfuzzer/core/httpoperation.py
+++ b/tntfuzzer/core/httpoperation.py
@@ -6,6 +6,7 @@ from random import Random
 
 from pyjfuzz.core.pjf_configuration import PJFConfiguration
 from pyjfuzz.core.pjf_factory import PJFFactory
+from pyjfuzz.core.errors import PJFInvalidType
 
 
 class HttpOperation:
@@ -29,7 +30,7 @@ class HttpOperation:
             try:
                 config = PJFConfiguration(Namespace(json=json.loads(json_str), nologo=True, level=6))
                 self.fuzzer = PJFFactory(config)
-            except:
+            except PJFInvalidType:
                 return json_str
         return self.fuzzer.fuzzed
 
@@ -111,7 +112,7 @@ class HttpOperation:
                     list_bodyitem.append(self.replicator.as_dict(object_type))
                 else:
                     object_type = parameter['schema']['items']['type']
-                    list_bodyitem.append(self.replicator.create_init_value(object_type))                
+                    list_bodyitem.append(self.replicator.create_init_value(object_type))
                 result += json.dumps(list_bodyitem)
             else:
                 object_type = parameter['schema']['type']

--- a/tntfuzzer/core/httpoperation.py
+++ b/tntfuzzer/core/httpoperation.py
@@ -11,7 +11,7 @@ from pyjfuzz.core.pjf_factory import PJFFactory
 class HttpOperation:
     def __init__(self, op_code, host_basepath, path, op_infos, headers, replicator, use_fuzzing=True, ignore_tls=False):
         self.op_code = op_code
-        self.url = host_basepath + path
+        self.url = host_basepath.rstrip("/") + "/" + path.lstrip("/")
         self.op_infos = op_infos
         self.use_fuzzing = use_fuzzing
         self.replicator = replicator
@@ -26,8 +26,11 @@ class HttpOperation:
             return json_str
 
         if self.fuzzer is None:
-            config = PJFConfiguration(Namespace(json=json.loads(json_str), nologo=True, level=6))
-            self.fuzzer = PJFFactory(config)
+            try:
+                config = PJFConfiguration(Namespace(json=json.loads(json_str), nologo=True, level=6))
+                self.fuzzer = PJFFactory(config)
+            except:
+                return json_str
         return self.fuzzer.fuzzed
 
     def execute(self):
@@ -100,11 +103,22 @@ class HttpOperation:
 
     def create_body(self, parameter):
         result = ''
-        if 'type' in parameter['schema'] and parameter['schema']['type'] == 'array':
-            object_type = parameter['schema']['items']['$ref']
-            list_bodyitem = list()
-            list_bodyitem.append(self.replicator.as_dict(object_type))
-            result += json.dumps(list_bodyitem)
+        if 'type' in parameter['schema']:
+            if parameter['schema']['type'] == 'array':
+                list_bodyitem = list()
+                if '$ref' in parameter['schema']['items']:
+                    object_type = parameter['schema']['items']['$ref']
+                    list_bodyitem.append(self.replicator.as_dict(object_type))
+                else:
+                    object_type = parameter['schema']['items']['type']
+                    list_bodyitem.append(self.replicator.create_init_value(object_type))                
+                result += json.dumps(list_bodyitem)
+            else:
+                object_type = parameter['schema']['type']
+                object_value = self.replicator.create_init_value(object_type)
+                if object_type == 'string':
+                    object_value = '"' + object_value + '"'
+                result += object_value
         else:
             object_type = parameter['schema']['$ref']
             result += self.replicator.as_json(object_type)

--- a/tntfuzzer/core/replicator.py
+++ b/tntfuzzer/core/replicator.py
@@ -54,7 +54,7 @@ class Replicator:
             else:
                 return False
         if object_type == 'object':
-            print(self.randomdict.items())
+            # FIXME: get props from object and rerun with data types
             return self.randomdict
         if object_type == 'file':
             return '/file/to/../something'  # TODO: react to init_rand_values

--- a/tntfuzzer/core/replicator.py
+++ b/tntfuzzer/core/replicator.py
@@ -55,7 +55,7 @@ class Replicator:
                 return False
         if object_type == 'object':
             # FIXME: get props from object and rerun with data types
-            return self.randomdict
+            return self.randomdict.__dict__
         if object_type == 'file':
             return '/file/to/../something'  # TODO: react to init_rand_values
         return self.replicate(object_type)

--- a/tntfuzzer/core/replicator.py
+++ b/tntfuzzer/core/replicator.py
@@ -2,6 +2,7 @@ import json
 import string
 import sys
 from random import Random
+from randomdict import RandomDict
 
 from core.pattern import Pattern
 
@@ -26,6 +27,7 @@ class Replicator:
         self.use_string_pattern = use_string_pattern
         self.max_string_len = max_string_len
         self.random = Random()
+        self.randomdict = RandomDict()
 
     def create_init_value(self, object_type):
         if object_type == 'integer':
@@ -51,6 +53,9 @@ class Replicator:
                 return bool(self.random.getrandbits(1))
             else:
                 return False
+        if object_type == 'object':
+            print(self.randomdict.items())
+            return self.randomdict
         if object_type == 'file':
             return '/file/to/../something'  # TODO: react to init_rand_values
         return self.replicate(object_type)
@@ -77,6 +82,7 @@ class Replicator:
                     array_type = object_schema['properties'][prop]['items']['type']
                 object_instance[prop] = list()
                 object_instance[prop].append(self.create_init_value(array_type))
+
             else:
                 object_instance[prop] = self.create_init_value(prop_type)
 

--- a/tntfuzzer/tests/core/curlcommandtest.py
+++ b/tntfuzzer/tests/core/curlcommandtest.py
@@ -14,7 +14,7 @@ class CurlCommandTest(TestCase):
         curlcommand = CurlCommand(url, method, data, headers)
 
         self.assertEqual(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" -d "
-                                             "'{\"id\": 1, \"name\": \"Foo\"}' http://example.com/api/v2/test")
+                                            "'{\"id\": 1, \"name\": \"Foo\"}' http://example.com/api/v2/test")
 
     def test_post_method(self):
         method = "pOsT"
@@ -24,7 +24,7 @@ class CurlCommandTest(TestCase):
         curlcommand = CurlCommand(url, method, data, headers)
 
         self.assertEqual(curlcommand.get(), "curl -XPOST -H \"Content-type: application/json\" -d "
-                                             "'{\"id\": 2, \"name\": \"Bar\"}' http://example.com/api/post")
+                                            "'{\"id\": 2, \"name\": \"Bar\"}' http://example.com/api/post")
 
     def test_empty_data(self):
         method = "get"
@@ -33,7 +33,7 @@ class CurlCommandTest(TestCase):
         headers = json.loads('{}')
         curlcommand = CurlCommand(url, method, data, headers)
         self.assertEqual(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" "
-                                             "http://example.com/api/v2/list")
+                                            "http://example.com/api/v2/list")
 
     def test_generate_headers(self):
         method = "get"

--- a/tntfuzzer/tests/core/curlcommandtest.py
+++ b/tntfuzzer/tests/core/curlcommandtest.py
@@ -13,7 +13,7 @@ class CurlCommandTest(TestCase):
         headers = json.loads('{}')
         curlcommand = CurlCommand(url, method, data, headers)
 
-        self.assertEquals(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" -d "
+        self.assertEqual(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" -d "
                                              "'{\"id\": 1, \"name\": \"Foo\"}' http://example.com/api/v2/test")
 
     def test_post_method(self):
@@ -23,7 +23,7 @@ class CurlCommandTest(TestCase):
         headers = json.loads('{}')
         curlcommand = CurlCommand(url, method, data, headers)
 
-        self.assertEquals(curlcommand.get(), "curl -XPOST -H \"Content-type: application/json\" -d "
+        self.assertEqual(curlcommand.get(), "curl -XPOST -H \"Content-type: application/json\" -d "
                                              "'{\"id\": 2, \"name\": \"Bar\"}' http://example.com/api/post")
 
     def test_empty_data(self):
@@ -32,7 +32,7 @@ class CurlCommandTest(TestCase):
         data = ""
         headers = json.loads('{}')
         curlcommand = CurlCommand(url, method, data, headers)
-        self.assertEquals(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" "
+        self.assertEqual(curlcommand.get(), "curl -XGET -H \"Content-type: application/json\" "
                                              "http://example.com/api/v2/list")
 
     def test_generate_headers(self):
@@ -43,7 +43,7 @@ class CurlCommandTest(TestCase):
         expected_result = u'-H \"Content-type: application/json\" -H \"X-API-Key\": \"abcdef12345\" ' \
                           u'-H \"user-agent\": \"tntfuzzer\"'
         curlcommand = CurlCommand(url, method, data, headers)
-        self.assertEquals(curlcommand.generate_headers(), expected_result)
+        self.assertEqual(curlcommand.generate_headers(), expected_result)
 
     def test_generate_headers_returns_contenttype_only_when_headers_nonetype(self):
         method = "get"
@@ -53,4 +53,4 @@ class CurlCommandTest(TestCase):
 
         curlcommand = CurlCommand(url, method, data, None)
 
-        self.assertEquals(curlcommand.generate_headers(), expected_result)
+        self.assertEqual(curlcommand.generate_headers(), expected_result)


### PR DESCRIPTION
## Purpose
Fix the following bug https://github.com/Teebytes/TnT-Fuzzer/issues/39 and a few other issues

## Approach
This pull request incorporates original fix by @xenobyte bugfix/#39
I found several other issues on our swagger.json and fixed them as well:
Stop failing for 'type' : 'object'
Stop failing for 'type' : 'string' with application/json content type
Stop failing for arrays of strings
Avoid double slash in URI when base path is '/'

## Added tests?
Manual testing was done.

