### PR TITLE
Support OpenAPI 3.0

### DIFF
--- a/tntfuzzer/core/httpoperation.py
+++ b/tntfuzzer/core/httpoperation.py
@@ -43,18 +43,34 @@ class HttpOperation:
             for parameter in self.op_infos['parameters']:
                 # catch path parameters and replace them in url
                 if 'path' == parameter['in']:
-                    url = self.replace_url_parameter(url, parameter['name'], parameter['type'])
+                    if 'type' in parameter:
+                        parameter_type = parameter['type']
+                    elif 'type' in parameter['schema']:
+                        parameter_type = parameter['schema']['type']
+                    else:
+                        parameter_type = parameter['schema']['$ref'].split('/')[-1]
+                    url = self.replace_url_parameter(url, parameter['name'], parameter_type)
 
                 if 'body' == parameter['in']:
                     self.request_body = self.create_body(parameter)
                     self.request_body = self.fuzz(self.request_body)
 
                 if 'formData' == parameter['in'] or 'query' == parameter['in']:
-                    type_cls = parameter['type']
+                    if 'type' in parameter:
+                        type_cls = parameter['type']
+                    elif 'type' in parameter['schema']:
+                        type_cls = parameter['schema']['type']
+                    else:
+                        type_cls = parameter['schema']['$ref'].split('/')[-1]
                     if 'array' == type_cls:
-                        type_cls = parameter['items']['type']
+                        if 'items' in parameter and 'type' in parameter['items']:
+                            type_cls = parameter['items']['type']
+                        if 'schema' in parameter and 'items' in parameter['schema'] and 'type' in parameter['schema']['items']:
+                            type_cls = parameter['schema']['items']['type']
+                        else:
+                            type_cls = parameter['schema']['items']['$ref'].split('/')[-1]
 
-                    if self.is_parameter_not_optional_but_randomize(parameter['required']):
+                    if 'required' in parameter and self.is_parameter_not_optional_but_randomize(parameter['required']):
                         form_data[parameter['name']] = self.create_form_parameter(type_cls)
 
         if self.op_code == 'post':

--- a/tntfuzzer/core/httpoperation.py
+++ b/tntfuzzer/core/httpoperation.py
@@ -65,7 +65,8 @@ class HttpOperation:
                     if 'array' == type_cls:
                         if 'items' in parameter and 'type' in parameter['items']:
                             type_cls = parameter['items']['type']
-                        if 'schema' in parameter and 'items' in parameter['schema'] and 'type' in parameter['schema']['items']:
+                        if ('schema' in parameter and 'items' in parameter['schema'] and
+                           'type' in parameter['schema']['items']):
                             type_cls = parameter['schema']['items']['type']
                         else:
                             type_cls = parameter['schema']['items']['$ref'].split('/')[-1]

--- a/tntfuzzer/core/replicator.py
+++ b/tntfuzzer/core/replicator.py
@@ -69,6 +69,8 @@ class Replicator:
 
         object_schema = self.definitions[object_class]
         object_instance = {}
+        if 'enum' in object_schema:
+            return self.random.choice(object_schema['enum'])
         for prop in object_schema['properties']:
             if 'type' in object_schema['properties'][prop]:
                 prop_type = object_schema['properties'][prop]['type']

--- a/tntfuzzer/utils/strutils.py
+++ b/tntfuzzer/utils/strutils.py
@@ -1,4 +1,5 @@
 import termcolor
+import sys
 
 
 class StrUtils:
@@ -8,14 +9,20 @@ class StrUtils:
 
     @staticmethod
     def print_log_row(op_code, url, status_code, documented_reason, body, curlcommand):
+        if type(curlcommand) == str:
+            curlstr = curlcommand
+        else:
+            curlstr = curlcommand.get()
         print(termcolor.colored(StrUtils.fill_string_up_with_blanks(op_code, 7), color='red') + ' | ' +
               termcolor.colored(StrUtils.fill_string_up_with_blanks(url, 100), color='green') + ' |-| ' +
               StrUtils.fill_string_up_with_blanks(status_code, 3) + ' | ' +
               StrUtils.fill_string_up_with_blanks(documented_reason, 20) + ' | ' +
-              body + ' | ' + curlcommand.get())
+              body + ' | ' + curlstr)
 
     @staticmethod
     def fill_string_up_with_blanks(fillup_string, num_chars):
+        if fillup_string is None:
+            return 'None   '
         if len(fillup_string) > num_chars:
             return fillup_string
         else:


### PR DESCRIPTION
- Support OpenAPI 3.0
- Add ignored paths argument: allows to exclude some paths from fuzzing

## Purpose
Current implementation supports only Swagger 2.0 specifications. This change adds support for OpenAPI 3.0 format.
Also added --ignored-paths parameter, to be able to avoid calling undesired APIs. For example calling delete on oauth token path can drop the authentication, which is usually not desired.

## Goals
Support fuzzing of servers implementing OpenAPI 3.0

## Approach
OpenAPI 3.0 specification JSON doesn't contain 'swagger' element, but contains 'openapi' element instead.
Some parameter type specifications have different JSON structure.
There's a list of base URIs instead of separate scheme and host declaration.

## Added tests?
Tested manually on the server that implements OpenAPI 3.0 via Swashbuckle.AspNetCore

