### PR TITLE
Added proxy support

### DIFF
--- a/tntfuzzer/core/curlcommand.py
+++ b/tntfuzzer/core/curlcommand.py
@@ -21,10 +21,10 @@ class CurlCommand:
 
     def get(self):
         if not self.data or len(self.data) < 1:
-            curl_command = "curl " + self.ignore_tls + self.proxy + "-X" + self.method.upper() + " " + self.generate_headers() \
+            curl_command = "curl " + self.ignore_tls + self.proxy + " -X" + self.method.upper() + " " + self.generate_headers() \
                            + " " + self.url
         else:
-            curl_command = "curl " + self.ignore_tls + self.proxy + "-X" + self.method.upper() + " " + \
+            curl_command = "curl " + self.ignore_tls + self.proxy + " -X" + self.method.upper() + " " + \
                            self.generate_headers() + " -d '" + self.data + "' " + self.url
 
         return curl_command

--- a/tntfuzzer/core/curlcommand.py
+++ b/tntfuzzer/core/curlcommand.py
@@ -3,7 +3,7 @@ import json
 
 class CurlCommand:
 
-    def __init__(self, url, method, data, headers, ignore_tls=False):
+    def __init__(self, url, method, data, headers, ignore_tls=False, proxy=None):
         self.url = url
         self.method = method
         self.data = data
@@ -13,13 +13,18 @@ class CurlCommand:
             self.ignore_tls = "-k "  # short for --insecure
         else:
             self.ignore_tls = ""
+        
+        if proxy:
+            self.proxy = "--proxy " + proxy
+        else:
+            self.proxy = ""
 
     def get(self):
         if not self.data or len(self.data) < 1:
-            curl_command = "curl " + self.ignore_tls + "-X" + self.method.upper() + " " + self.generate_headers() \
+            curl_command = "curl " + self.ignore_tls + self.proxy + "-X" + self.method.upper() + " " + self.generate_headers() \
                            + " " + self.url
         else:
-            curl_command = "curl " + self.ignore_tls + "-X" + self.method.upper() + " " + \
+            curl_command = "curl " + self.ignore_tls + self.proxy + "-X" + self.method.upper() + " " + \
                            self.generate_headers() + " -d '" + self.data + "' " + self.url
 
         return curl_command

--- a/tntfuzzer/core/httpoperation.py
+++ b/tntfuzzer/core/httpoperation.py
@@ -10,7 +10,7 @@ from pyjfuzz.core.errors import PJFInvalidType
 
 
 class HttpOperation:
-    def __init__(self, op_code, host_basepath, path, op_infos, headers, replicator, use_fuzzing=True, ignore_tls=False):
+    def __init__(self, op_code, host_basepath, path, op_infos, headers, replicator, use_fuzzing=True, ignore_tls=False, proxy=None):
         self.op_code = op_code
         self.url = host_basepath.rstrip("/") + "/" + path.lstrip("/")
         self.op_infos = op_infos
@@ -20,6 +20,8 @@ class HttpOperation:
         self.request_body = None
         self.headers = headers
         self.ignore_tls = ignore_tls
+        self.proxies = {'http':proxy, 'https':proxy}
+        #self.proxies = {'http':'http://host.docker.internal:8081', 'https':'http://host.docker.internal:8081'}
         self.random = Random()
 
     def fuzz(self, json_str):
@@ -83,22 +85,22 @@ class HttpOperation:
 
         if self.op_code == 'post':
             if bool(form_data):
-                response = requests.post(url=url, data=form_data, json=None, headers=self.headers, verify=verify_tls)
+                response = requests.post(url=url, data=form_data, json=None, headers=self.headers, verify=verify_tls, proxies=self.proxies)
             else:
                 response = requests.post(url=url, data=None, json=self.request_body, headers=self.headers,
                                          verify=verify_tls)
 
         elif self.op_code == 'get':
-            response = requests.get(url=url, params=form_data, headers=self.headers, verify=verify_tls)
+            response = requests.get(url=url, params=form_data, headers=self.headers, verify=verify_tls, proxies=self.proxies)
 
         elif self.op_code == 'delete':
-            response = requests.delete(url=url, headers=self.headers, verify=verify_tls)
+            response = requests.delete(url=url, headers=self.headers, verify=verify_tls, proxies=self.proxies)
 
         elif self.op_code == 'put':
-            response = requests.put(url=url, data=form_data, headers=self.headers, verify=verify_tls)
+            response = requests.put(url=url, data=form_data, headers=self.headers, verify=verify_tls, proxies=self.proxies)
 
         elif self.op_code == 'patch':
-            response = requests.patch(url=url, data=form_data, headers=self.headers, verify=verify_tls)
+            response = requests.patch(url=url, data=form_data, headers=self.headers, verify=verify_tls, proxies=self.proxies)
 
         else:
             response = None

--- a/tntfuzzer/core/httpoperation.py
+++ b/tntfuzzer/core/httpoperation.py
@@ -42,14 +42,21 @@ class HttpOperation:
         if 'parameters' in self.op_infos:
             for parameter in self.op_infos['parameters']:
                 # catch path parameters and replace them in url
-                if 'path' == parameter['in']:
-                    if 'type' in parameter:
-                        parameter_type = parameter['type']
-                    elif 'type' in parameter['schema']:
-                        parameter_type = parameter['schema']['type']
-                    else:
-                        parameter_type = parameter['schema']['$ref'].split('/')[-1]
-                    url = self.replace_url_parameter(url, parameter['name'], parameter_type)
+
+                # sometimes KeyError is thrown here
+                try:
+                    if 'path' == parameter['in']:
+                        if 'type' in parameter:
+                            parameter_type = parameter['type']
+                        elif 'type' in parameter['schema']:
+                            parameter_type = parameter['schema']['type']
+                        else:
+                            parameter_type = parameter['schema']['$ref'].split('/')[-1]
+                        url = self.replace_url_parameter(url, parameter['name'], parameter_type)
+                except KeyError:
+                    #print("Error: no key 'in' for this parameter")
+                    #print(parameter)
+                    continue
 
                 if 'body' == parameter['in']:
                     self.request_body = self.create_body(parameter)


### PR DESCRIPTION
## Purpose
I wanted to use this tool in combination with Burp Suite, but there was no proxy argument for the script, so I implemented proxy support.

## Goals
It is now possible to use a proxy to route each request.

## Approach
Modified the main file `tntfuzzer.py` to parse an additional argument `--proxy`.

Modified `CurlCommand` and `HttpOperation` classes to take in an additional argument called `proxy` and use it in respective methods.

Also I was receiving a strange KeyError. Here is the error log:
```
Traceback (most recent call last):
  File "/app/tntfuzzer/tntfuzzer.py", line 258, in <module>
    main()
  File "/app/tntfuzzer/tntfuzzer.py", line 252, in main
    tnt.start()
  File "/app/tntfuzzer/tntfuzzer.py", line 155, in start
    response = operation.execute()
  File "/app/tntfuzzer/core/httpoperation.py", line 49, in execute
    if 'path' == parameter['in']:
KeyError: 'in'
```
This was happening even though the `swagger.json` file is fine, so I wrapped this call in a `try-except` block, which handles this error by simply continuing to the next iteration. This fix is present as a separate commit.

## Added tests?
No tests added.

